### PR TITLE
.end() callbacks

### DIFF
--- a/lib/farm.js
+++ b/lib/farm.js
@@ -176,8 +176,8 @@ var Farm = {
       , end: function (callback) {
           var complete = true
           if (this.ending === false) return
-          // Only overwrite if a callback is being added.
-          if (callback) this.ending = callback;
+          if (callback) this.ending = callback
+          else if (this.ending == null) this.ending = true
           Object.keys(this.children).forEach(function (child) {
             if (!this.children[child]) return
             if (!this.children[child].activeCalls)

--- a/tests/index.js
+++ b/tests/index.js
@@ -234,3 +234,19 @@ tape('durability', function (t) {
     })
   }
 })
+
+// a callback provided to .end() can and will be called (uses "simple, exports=function test" to create a child)
+tape('simple, end callback', function (t) {
+  t.plan(4)
+
+  var child = workerFarm(childPath)
+  child(0, function (err, pid, rnd) {
+    t.ok(pid > process.pid, 'pid makes sense')
+    t.ok(pid < process.pid + 100, 'pid makes sense')
+    t.ok(rnd > 0 && rnd < 1, 'rnd result makes sense')
+  })
+
+  workerFarm.end(child, function() {
+    t.pass('an .end() callback was successfully called')
+  });
+})


### PR DESCRIPTION
I'm not entirely sure whether or not this was intentional, from the looks of it it's never possible for a Farm.end() callback to actually be called. Not only that, but because Farm.end() is called from multiple places withen the object without a callback, when the worker queue is actually complete the ending callback was being overwritten to a boolean.
