### PR TITLE
Add a test to verify that error messages are passed from the child

### DIFF
--- a/tests/child.js
+++ b/tests/child.js
@@ -14,3 +14,7 @@ module.exports.killable = function (id, callback) {
     return process.exit(-1)
   callback(null, id, process.pid)
 }
+
+module.exports.returnsError = function (callback) {
+  callback(new Error('whoops'))
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -250,3 +250,14 @@ tape('simple, end callback', function (t) {
     t.pass('an .end() callback was successfully called')
   });
 })
+
+tape('error from callback', function (t) {
+  t.plan(1)
+
+  var child = workerFarm(childPath, ['returnsError'])
+  child.returnsError(function(err) {
+    t.equal(err.message, 'whoops', 'error message from child is passed correctly')
+  })
+
+  workerFarm.end(child, t.end.bind(t))
+})


### PR DESCRIPTION
The test does _not_ currently pass. It is to verify that the issue reported in #9 exists.
