### PR TITLE
Add data property to errors

### DIFF
--- a/lib/child/index.js
+++ b/lib/child/index.js
@@ -20,6 +20,7 @@ function handle (data) {
             , 'type'    : _args[0].constructor.name
             , 'message' : _args[0].message
             , 'stack'   : _args[0].stack
+            , 'data'    : _args[0].data
           }
         }
         process.send({ idx: idx, child: child, args: _args })

--- a/lib/farm.js
+++ b/lib/farm.js
@@ -171,6 +171,7 @@ Farm.prototype.receive = function (data) {
     }
     args[0].type = e.type
     args[0].stack = e.stack
+    args[0].data = e.data
   }
 
   process.nextTick(function () {

--- a/lib/farm.js
+++ b/lib/farm.js
@@ -171,7 +171,11 @@ Farm.prototype.receive = function (data) {
     }
     args[0].type = e.type
     args[0].stack = e.stack
-    args[0].data = e.data
+
+    // Copy any custom properties to pass it on.
+    Object.keys(e).forEach(function(key) {
+      args[0][key] = e[key];
+    });
   }
 
   process.nextTick(function () {

--- a/tests/child.js
+++ b/tests/child.js
@@ -17,7 +17,17 @@ module.exports.killable = function (id, callback) {
   callback(null, id, process.pid)
 }
 
-module.exports.err = function (type, message, callback) {
+module.exports.err = function (type, message, data, callback) {
+  if (typeof data == 'function') {
+    callback = data
+    data = null
+  } else {
+    var err = new Error(message)
+    err.data = data
+    callback(err)
+    return
+  }
+
   if (type == 'TypeError')
     return callback(new TypeError(message))
   callback(new Error(message))

--- a/tests/index.js
+++ b/tests/index.js
@@ -359,7 +359,7 @@ tape('call timeout test', function (t) {
 })
 
 tape('test error passing', function (t) {
-  t.plan(7)
+  t.plan(9)
 
   var child = workerFarm(childPath, [ 'err' ])
   child.err('Error', 'this is an Error', function (err) {
@@ -371,6 +371,10 @@ tape('test error passing', function (t) {
     t.ok(err instanceof Error, 'is a TypeError object')
     t.equal('TypeError', err.type, 'correct type')
     t.equal('this is a TypeError', err.message, 'correct message')
+  })
+  child.err('Error', 'this is an Error with data', {foo: 'bar'}, function (err) {
+    t.ok(err instanceof Error, 'is an Error object')
+    t.deepEqual(err.data, {foo: 'bar'}, 'passes data')
   })
 
   workerFarm.end(child, function () {


### PR DESCRIPTION
I need to pass more information in the error object to the master
process. The only way to currently do that is not to use errors at
all.

This adds a property 'data' on the error object is picked up when the
error is recreated by the master process.