### PR TITLE
Don't pass --debug to forked processes

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -2,7 +2,12 @@ const childProcess = require('child_process')
     , childModule  = require.resolve('./child/index')
 
 function fork (forkModule) {
-  var child = childProcess.fork(childModule, {
+  // suppress --debug flags while preserving others (like --harmony)
+  var filteredArgs = process.execArgv.filter(function (v) {
+  	return v.indexOf('--debug') === -1
+  })
+
+  var child = childProcess.fork(childModule, {execArgv: filteredArgs}, {
           env: process.env
         , cwd: process.cwd()
       })

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -4,7 +4,7 @@ const childProcess = require('child_process')
 function fork (forkModule) {
   // suppress --debug flags while preserving others (like --harmony)
   var filteredArgs = process.execArgv.filter(function (v) {
-  	return v.indexOf('--debug') === -1
+    return v.indexOf('--debug') === -1
   })
 
   var child = childProcess.fork(childModule, {execArgv: filteredArgs}, {

--- a/tests/child.js
+++ b/tests/child.js
@@ -7,6 +7,12 @@ module.exports = function (timeout, callback) {
   callback()
 }
 
+module.exports.args = function (callback) {
+  console.log(process.argv)
+  console.log(process.execArgv)
+  callback()
+}
+
 module.exports.run0 = function (callback) {
   module.exports(0, callback)
 }

--- a/tests/debug.js
+++ b/tests/debug.js
@@ -1,0 +1,8 @@
+var workerFarm = require('../')
+  , workers    = workerFarm(require.resolve('./child'), ['args'])
+
+workers.args(function() {
+  workerFarm.end(workers)
+  console.log('FINISHED')
+  process.exit(0)
+})

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,7 +1,8 @@
-var tape       = require('tape')
-  , workerFarm = require('../')
-  , childPath  = require.resolve('./child')
-  , fs         = require('fs')
+var tape          = require('tape')
+  , child_process = require('child_process')
+  , workerFarm    = require('../')
+  , childPath     = require.resolve('./child')
+  , fs            = require('fs')
 
   , uniq = function (ar) {
       var a = [], i, j
@@ -452,5 +453,21 @@ tape('test max retries after process terminate', function (t) {
   workerFarm.end(child2, function () {
     fs.unlinkSync(filepath2)
     t.ok(true, 'workerFarm ended')
+  })
+})
+
+tape('ensure --debug not propagated to children', function (t) {
+  t.plan(3)
+
+  var script = __dirname + '/debug.js'
+  var child = child_process.spawn('node', ['--debug=8881', script]);
+  var stdout = '';
+  child.stdout.on('data', function (data) {
+    stdout += data.toString()
+  })
+  child.on('close', function (code) {
+    t.ok(code === 0, 'exited without error')
+    t.ok(stdout.indexOf('FINISHED') > -1, 'process finished')
+    t.ok(stdout.indexOf('--debug') === -1, 'child does not receive debug flag')
   })
 })


### PR DESCRIPTION
This is a fix for #29 (which I was also experiencing). It prevents the `--debug` flag from being sent to the child forks, while not clobbering other node arguments like `--harmony`.
