### PR TITLE
Ability to use different modules in single farm

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,19 @@ Worker Farm allows me to spin up multiple JVMs to be controlled by Node, and hav
 
 Worker Farm exports a main function an an `end()` method. The main function sets up a "farm" of coordinated child-process workers and it can be used to instantiate multiple farms, all operating independently.
 
-### workerFarm([options, ]pathToModule[, exportedMethods])
+### workerFarm([options, pathToModule, exportedMethods])
 
 In its most basic form, you call `workerFarm()` with the path to a module file to be invoked by the child process. You should use an **absolute path** to the module file, the best way to obtain the path is with `require.resolve('./path/to/module')`, this function can be used in exactly the same way as `require('./path/to/module')` but it returns an absolute path.
+
+#### `pathToModule`
+By specifying `pathToModule` parameter you'll create farm bound to specified module. You can omit this parameter if you want to call functions from different modules. In such case you should pass path to module as first argument on worker call:
+
+```js
+var workers = workerFarm()
+workers(require.resolve('./mod1'), someArg, function () {})
+workers(require.resolve('./mod2'), someArg1, someArg2, function () {})
+```
+Note that in multi-mode your modules should export a single function.
 
 #### `exportedMethods`
 

--- a/lib/child/index.js
+++ b/lib/child/index.js
@@ -11,7 +11,8 @@ function handle (data) {
   var idx      = data.idx
     , child    = data.child
     , method   = data.method
-    , args     = data.args
+    , module   = $module || require(data.args[0])
+    , args     = $module ? data.args : data.args.slice(1)
     , callback = function () {
         var _args = Array.prototype.slice.call(arguments)
         if (_args[0] instanceof Error) {
@@ -30,10 +31,10 @@ function handle (data) {
       }
     , exec
 
-  if (method == null && typeof $module == 'function')
-    exec = $module
-  else if (typeof $module[method] == 'function')
-    exec = $module[method]
+  if (method == null && typeof module == 'function')
+    exec = module
+  else if (typeof module[method] == 'function')
+    exec = module[method]
 
   if (!exec)
     return console.error('NO SUCH METHOD:', method)
@@ -42,7 +43,7 @@ function handle (data) {
 }
 
 process.on('message', function (data) {
-  if (!$module) return $module = require(data.module)
+  if (data.module) return $module = require(data.module)
   if (data == 'die') return process.exit(0)
   handle(data)
 })

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -7,7 +7,7 @@ function fork (forkModule) {
         , cwd: process.cwd()
       })
 
-  child.send({ module: forkModule })
+  forkModule && child.send({ module: forkModule })
 
   // return a send() function for this child
   return {


### PR DESCRIPTION
This feature gives ability to have single worker farm, shared between different modules. And that modules can use different modules in workers.

```js
var workers = workerFarm();
workers(require.resolve('path/to/some-module'), arg, function(res) {...});
workers(require.resolve('path/to/some-other-module'), arg1, arg2, function(res) {...});
```