### PR TITLE
Provide an emitter to facilitate communication between farm and workers (e.g. progress updates)

### DIFF
--- a/examples/emittter/child.js
+++ b/examples/emittter/child.js
@@ -1,0 +1,8 @@
+module.exports = function (inp, callback) {
+  var that = this;
+  this.on("farm.*", function (txt, i) {
+    console.log(this.event, txt, i);
+    that.emit("worker.bar", "bar", i);
+  })
+  setTimeout(callback, 100, null, inp + ' BAR (' + process.pid + ')')
+}

--- a/examples/emittter/index.js
+++ b/examples/emittter/index.js
@@ -1,0 +1,16 @@
+var workerFarm = require('../../')
+  , workers    = workerFarm(require.resolve('./child'))
+  , ret        = 0
+
+for (var i = 0; i < 10; i++) {
+  var worker = workers('#' + i + ' FOO', function (err, outp) {
+    console.log(outp)
+    if (++ret == 10)
+      workerFarm.end(workers)
+  })
+
+  worker.on("worker.*", function (txt, i) {
+    console.log(this.event,txt, i);
+  })
+  worker.emit("farm.foo", "foo", i);
+}

--- a/lib/child/index.js
+++ b/lib/child/index.js
@@ -29,6 +29,7 @@ function handleCall (data) {
             _args[0][key] = e[key]
           })
         }
+        ;delete emitters[idx];
         process.send({ idx: idx, child: child, args: _args })
       }
     , exec

--- a/lib/child/index.js
+++ b/lib/child/index.js
@@ -1,4 +1,7 @@
+const EventEmitter2 = require('eventemitter2').EventEmitter2
+
 var $module
+  , emitters = []
 
 /*
   var contextProto = this.context;
@@ -7,7 +10,7 @@ var $module
   }
 */
 
-function handle (data) {
+function handleCall (data) {
   var idx      = data.idx
     , child    = data.child
     , method   = data.method
@@ -29,6 +32,7 @@ function handle (data) {
         process.send({ idx: idx, child: child, args: _args })
       }
     , exec
+    , emitter
 
   if (method == null && typeof $module == 'function')
     exec = $module
@@ -38,11 +42,37 @@ function handle (data) {
   if (!exec)
     return console.error('NO SUCH METHOD:', method)
 
-  exec.apply(null, args.concat([ callback ]))
+  // start listening for all events from the worker to forward them to the farm
+  emitter = emitters[idx] = new EventEmitter2({wildcard:true});
+  emitter.on('worker.*', function () {
+    process.send({
+        idx    : idx
+      , child  : child
+      , event  : this.event
+      , args   : Array.prototype.slice.call(arguments)
+    })
+  })
+
+  exec.apply(emitter, args.concat([ callback ]))
+}
+
+function handleEvent (data) {
+  var idx      = data.idx
+    , child    = data.child
+    , event    = data.event
+    , args     = data.args
+    , emitter  = emitters[idx]
+
+  if (!emitter)
+    return console.error('UNKNOWN CALL')
+
+  args.unshift(event);
+  emitter.emit.apply(emitter, args);
 }
 
 process.on('message', function (data) {
   if (!$module) return $module = require(data.module)
   if (data == 'die') return process.exit(0)
-  handle(data)
+  if (data.event) return handleEvent(data);
+  handleCall(data)
 })

--- a/lib/farm.js
+++ b/lib/farm.js
@@ -10,6 +10,7 @@ const DEFAULT_OPTIONS = {
       }
 
 const extend                  = require('xtend')
+    , EventEmitter2           = require('eventemitter2').EventEmitter2
     , fork                    = require('./fork')
     , TimeoutError            = require('errno').create('TimeoutError')
     , ProcessTerminatedError  = require('errno').create('ProcessTerminatedError')
@@ -31,12 +32,19 @@ Farm.prototype.mkhandle = function (method) {
         return process.nextTick(args[args.length - 1].bind(null, err))
       throw err
     }
+
+    // create a new EventEmitter for every call
+    var emitter = new EventEmitter2({wildcard:true});
     this.addCall({
         method   : method
       , callback : args.pop()
+      , emitter  : emitter
       , args     : args
       , retries  : 0
     })
+
+    // and return it to the user
+    return emitter;
   }.bind(this)
 }
 
@@ -135,6 +143,7 @@ Farm.prototype.stopChild = function (childId) {
 Farm.prototype.receive = function (data) {
   var idx     = data.idx
     , childId = data.child
+    , event   = data.event
     , args    = data.args
     , child   = this.children[childId]
     , call
@@ -153,6 +162,11 @@ Farm.prototype.receive = function (data) {
         'Worker Farm: Received message for unknown index for existing child. '
       + 'This should not happen!'
     )
+  }
+
+  if (event) {
+    args.unshift(event);
+    return call.emitter.emit.apply(call.emitter, args);
   }
 
   if (this.options.maxCallTime !== Infinity)
@@ -227,6 +241,16 @@ Farm.prototype.send = function (childId, call) {
     , child  : childId
     , method : call.method
     , args   : call.args
+  })
+
+  // start listening for all events from the farm to forward them to this child
+  call.emitter.on('farm.*', function () {
+    child.send({
+        idx    : idx
+      , child  : childId
+      , event  : this.event
+      , args   : Array.prototype.slice.call(arguments)
+    })
   })
 
   if (this.options.maxCallTime !== Infinity) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "errno": ">=0.1.1 <0.2.0-0",
-    "xtend": ">=4.0.0 <4.1.0-0"
+    "xtend": ">=4.0.0 <4.1.0-0",
+    "eventemitter2": ">=0.4.14"
   },
   "devDependencies": {
     "tape": ">=3.0.3 <3.1.0-0"


### PR DESCRIPTION
A call to `workers` now returns an EventEmitter2 that can be used to emit events to the child handling that call. To do so, without breaking the API, the child method is applied with a similar emitter as context. This can also be used to emit events back to the farm. To distinguish the direction in which events should be send, they have to be namespaced with `worker.*` and `farm.*`.
