### PR TITLE
Add farm-cli reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Any calls that are queued and not yet being handled by a child process will be d
 
 Once you end a farm, it won't handle any more calls, so don't even try!
 
+## Related
+
+* [worker-farm-cli](https://github.com/Kikobeats/worker-farm-cli#worker-farm-cli) – Launch a farm of worker from the CLI.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Once you end a farm, it won't handle any more calls, so don't even try!
 
 ## Related
 
-* [worker-farm-cli](https://github.com/Kikobeats/worker-farm-cli#worker-farm-cli) – Launch a farm of workers from CLI.
+* [farm-cli](https://github.com/Kikobeats/farm-cli) – Launch a farm of workers from CLI.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Once you end a farm, it won't handle any more calls, so don't even try!
 
 ## Related
 
-* [worker-farm-cli](https://github.com/Kikobeats/worker-farm-cli#worker-farm-cli) – Launch a farm of worker from the CLI.
+* [worker-farm-cli](https://github.com/Kikobeats/worker-farm-cli#worker-farm-cli) – Launch a farm of workers from CLI.
 
 ## License
 


### PR DESCRIPTION
I created a little CLI tool based in your library to make easy create a worker farm of whatever file.

The think that I find useful is that support file configuration (called `worker-farm.opts). If exists in the path of the file destination it will load the farm configuration.

Also pass as param the id of the worker. This is also useful when you need associate logging messages per each worker.

What do you think about that?
