### PR TITLE
Allow overriding `execArgv`

### DIFF
--- a/lib/farm.js
+++ b/lib/farm.js
@@ -7,6 +7,7 @@ const DEFAULT_OPTIONS = {
         , maxRetries                  : Infinity
         , forcedKillTime              : 100
         , autoStart                   : false
+        , execArgv                    : process.execArgv
       }
 
 const extend                  = require('xtend')
@@ -96,7 +97,7 @@ Farm.prototype.onExit = function (childId) {
 Farm.prototype.startChild = function () {
   this.childId++
 
-  var forked = fork(this.path)
+  var forked = fork(this.path, this.options)
     , id     = this.childId
     , c      = {
           send        : forked.send

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -1,10 +1,11 @@
 const childProcess = require('child_process')
     , childModule  = require.resolve('./child/index')
 
-function fork (forkModule) {
+function fork (forkModule, options) {
   var child = childProcess.fork(childModule, {
           env: process.env
         , cwd: process.cwd()
+        , execArgv: options.execArgv || []
       })
 
   child.send({ module: forkModule })


### PR DESCRIPTION
This adds the possibility to override `execArgv`. My main use case is to make the parent process debuggable without passing `--debug`, `--inspect`, etc. on to the children.

But it can be used to specify any custom node/v8 flags for child processes.