### PR TITLE
Allow overriding fork options

### DIFF
--- a/lib/farm.js
+++ b/lib/farm.js
@@ -9,6 +9,7 @@ const DEFAULT_OPTIONS = {
         , maxRetries                  : Infinity
         , forcedKillTime              : 100
         , autoStart                   : false
+        , forkOptions                 : {}
       }
 
 const extend                  = require('xtend')
@@ -103,7 +104,7 @@ Farm.prototype.onExit = function (childId) {
 Farm.prototype.startChild = function () {
   this.childId++
 
-  let forked = fork(this.path)
+  let forked = fork(this.path, this.options.forkOptions)
     , id     = this.childId
     , c      = {
           send        : forked.send

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -2,17 +2,21 @@
 
 const childProcess = require('child_process')
     , childModule  = require.resolve('./child/index')
+    , extend       = require('xtend')
 
 
-function fork (forkModule) {
+function fork (forkModule, options) {
   // suppress --debug / --inspect flags while preserving others (like --harmony)
   let filteredArgs = process.execArgv.filter(function (v) {
         return !(/^--(debug|inspect)/).test(v)
       })
-    , child        = childProcess.fork(childModule, { execArgv: filteredArgs }, {
+    , defaultOptions = {
           env: process.env
         , cwd: process.cwd()
-      })
+      }
+    , child        = childProcess.fork(childModule, { execArgv: filteredArgs },
+        extend(defaultOptions, options)
+      )
 
   child.send({ module: forkModule })
 

--- a/tests/child.js
+++ b/tests/child.js
@@ -79,6 +79,11 @@ module.exports.stubborn = function (path, callback) {
 }
 
 
+module.exports.env = function (callback) {
+  callback(null, process.env)
+}
+
+
 let started = Date.now()
 module.exports.uptime = function(callback) {
   callback(null, Date.now() - started)

--- a/tests/index.js
+++ b/tests/index.js
@@ -491,3 +491,21 @@ tape('ensure --debug/--inspect not propagated to children', function (t) {
     t.ok(stdout.indexOf('--debug') === -1, 'child does not receive debug flag')
   })
 })
+
+
+tape('test fork options', function (t) {
+  t.plan(3)
+  let env = process.env
+  env.foo = 'bar'
+  let options = { forkOptions: { env } }
+
+  let child = workerFarm(options, childPath, [ 'env' ])
+  child.env(function (err, result) {
+    t.notOk(err, 'no error')
+    t.equal(result.foo, env.foo, 'env var passed to child correctly')
+  })
+
+  workerFarm.end(child, function () {
+    t.ok(true, 'workerFarm ended')
+  })
+})


### PR DESCRIPTION
Similar #42, but generalizes a bit more by allowing all fork options to be overridden (instead of just `execArgv`). For my particular need, I needed to set `execPath` to something else that babelfies the js program.