### PR TITLE
fix: passing of 'process.argv' to sub processes

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -9,8 +9,9 @@ function fork (forkModule) {
   let filteredArgs = process.execArgv.filter(function (v) {
         return !(/^--(debug|inspect)/).test(v)
       })
-    , child        = childProcess.fork(childModule, { execArgv: filteredArgs }, {
-          env: process.env
+    , child        = childProcess.fork(childModule, process.argv, {
+          execArgv: filteredArgs
+        , env: process.env
         , cwd: process.cwd()
       })
 


### PR DESCRIPTION
@rvagg 

According to the [doc](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options) the current call of `child.fork` is incorrect; this PR fixes the bug.