### PR TITLE
feat: ability to call method in all workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,22 @@ Listing the available methods will instruct Worker Farm what API to provide you 
 
 **It is assumed that each function you call on your child module will take a `callback` function as the last argument.**
 
+##### broadcast call
+
+You can call some function in all workers. To do this you should specify method via object with `broadcast` property set to true
+
+```js
+var workers = workerFarm(require.resolve('./mod'), [
+  {name: 'init', broadcast: true}, // broadcast method
+  {name: 'doSomething'}, // plain method
+  'doOtherThing' // plain method
+})
+```
+
+Broadcast method will be called in all child processes. Its callback will be called with the first occured error if any or with an array of results.
+
+**Note that any broadcast method will be called in all children started before the moment of call but not for those started after. So if you want to be sure that broadcast method will be called in all children you should enable `autoStart` option
+
 #### `options`
 
 If you don't provide an `options` object then the following defaults will be used:

--- a/lib/farm.js
+++ b/lib/farm.js
@@ -45,6 +45,47 @@ Farm.prototype.mkhandle = function (method) {
 }
 
 
+// make a broadcast handle, which will send call to all children
+Farm.prototype.mkBroadcastHandle = function (method) {
+  return function () {
+    let args = Array.prototype.slice.call(arguments)
+    const childKeys = Object.keys(this.children);
+
+    if (this.activeCalls + childKeys.length > this.options.maxConcurrentCalls) {
+      let err = new MaxConcurrentCallsError('Too many concurrent calls (' + this.activeCalls + ')')
+      if (typeof args[args.length - 1] == 'function')
+        return process.nextTick(args[args.length - 1].bind(null, err))
+      throw err
+    }
+
+    const callback = args.pop()
+    const results = []
+    const errors = []
+
+    function subCallback(err, res) {
+      if (err) {
+        errors.push(err)
+      } else {
+        results.push(res)
+      }
+
+      if (results.length + errors.length === childKeys.length) {
+        callback(errors[0] || null, results)
+      }
+    }
+
+    childKeys.forEach(function (key) {
+      this.addCall({
+          method   : method
+        , callback : subCallback
+        , args     : args
+        , retries  : 0
+        , childKey : key
+      })
+    }.bind(this))
+  }.bind(this)
+}
+
 // a constructor of sorts
 Farm.prototype.setup = function (methods) {
   let iface
@@ -53,7 +94,8 @@ Farm.prototype.setup = function (methods) {
   } else { // multiple functions on the export
     iface = {}
     methods.forEach(function (m) {
-      iface[m] = this.mkhandle(m)
+      const _m = typeof m === 'string' ? {name: m} : m;
+      iface[_m.name] = _m.broadcast ? this.mkBroadcastHandle(_m.name) : this.mkhandle(_m.name)
     }.bind(this))
   }
 
@@ -265,6 +307,16 @@ Farm.prototype.childKeys = function () {
 }
 
 
+Farm.prototype.getNextCallFromQueue = function (childId) {
+  for (let i = 0; i < this.callQueue.length; ++i) {
+    const call = this.callQueue[i];
+    if (!call.childKey || call.childKey == childId) {
+      return this.callQueue.splice(i, 1)[0]
+    }
+  }
+}
+
+
 // Calls are added to a queue, this processes the queue and is called
 // whenever there might be a chance to send more calls to the workers.
 // The various options all impact on when we're able to send calls,
@@ -283,9 +335,12 @@ Farm.prototype.processQueue = function () {
     if (this.children[childId].activeCalls < this.options.maxConcurrentCallsPerWorker
         && this.children[childId].calls.length < this.options.maxCallsPerWorker) {
 
-      this.send(childId, this.callQueue.shift())
-      if (!this.callQueue.length)
-        return this.ending && this.end()
+      const call = this.getNextCallFromQueue(childId)
+      if (call) {
+        this.send(childId, call)
+        if (!this.callQueue.length)
+          return this.ending && this.end()
+      }
     } /*else {
       console.log(
         , this.children[childId].activeCalls < this.options.maxConcurrentCallsPerWorker


### PR DESCRIPTION
This feature allows to call some method in all workers.
My use case is to perform asynchronous initialization in all workers before any other call. And get some accumulated statistics after the work is done

**This feature is backwards compatible**