### PR TITLE
Wrap NO SUCH METHOD: in an Error

### DIFF
--- a/lib/child/index.js
+++ b/lib/child/index.js
@@ -39,7 +39,7 @@ function handle (data) {
     exec = $module[method]
 
   if (!exec)
-    return console.error('NO SUCH METHOD:', method)
+    return console.error(new Error('NO SUCH METHOD: ' + method))
 
   exec.apply(null, args.concat([ callback ]))
 }


### PR DESCRIPTION
Gives us a stacktrace so we can find where it originates from

![image](https://user-images.githubusercontent.com/1404810/30240606-bfba5458-9573-11e7-814b-cd6946d234fe.png)

vs.

![image](https://user-images.githubusercontent.com/1404810/30240607-c63f7dc6-9573-11e7-87fa-ed276124f37a.png)