### PR TITLE
Allow customizing all "childProcess.fork" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ If you don't provide an `options` object then the following defaults will be use
 
 ```js
 {
-    maxCallsPerWorker           : Infinity
+    workerOptions               : {}
+  , maxCallsPerWorker           : Infinity
   , maxConcurrentWorkers        : require('os').cpus().length
   , maxConcurrentCallsPerWorker : 10
   , maxConcurrentCalls          : Infinity
@@ -112,6 +113,8 @@ If you don't provide an `options` object then the following defaults will be use
   , autoStart                   : false
 }
 ```
+
+  * **<code>workerOptions</code>** allows you to customize all the parameters passed to child nodes. This object supports [all possible options of `child_process.fork`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options). The default options passed are the parent `execArgv`, `cwd` and `env`. Any (or all) of them can be overridden, and others can be added as well.
 
   * **<code>maxCallsPerWorker</code>** allows you to control the lifespan of your child processes. A positive number will indicate that you only want each child to accept that many calls before it is terminated. This may be useful if you need to control memory leaks or similar in child processes.
 

--- a/lib/farm.js
+++ b/lib/farm.js
@@ -1,7 +1,8 @@
 'use strict'
 
 const DEFAULT_OPTIONS = {
-          maxCallsPerWorker           : Infinity
+          workerOptions               : {}
+        , maxCallsPerWorker           : Infinity
         , maxConcurrentWorkers        : require('os').cpus().length
         , maxConcurrentCallsPerWorker : 10
         , maxConcurrentCalls          : Infinity
@@ -103,7 +104,7 @@ Farm.prototype.onExit = function (childId) {
 Farm.prototype.startChild = function () {
   this.childId++
 
-  let forked = fork(this.path)
+  let forked = fork(this.path, this.options.workerOptions)
     , id     = this.childId
     , c      = {
           send        : forked.send

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -2,18 +2,20 @@
 
 const childProcess = require('child_process')
     , childModule  = require.resolve('./child/index')
+    , extend       = require('xtend')
 
 
-function fork (forkModule) {
+function fork (forkModule, workerOptions) {
   // suppress --debug / --inspect flags while preserving others (like --harmony)
-  let filteredArgs = process.execArgv.filter(function (v) {
+  let filteredArgs  = process.execArgv.filter(function (v) {
         return !(/^--(debug|inspect)/).test(v)
       })
-    , child        = childProcess.fork(childModule, process.argv, {
-          execArgv: filteredArgs
-        , env: process.env
-        , cwd: process.cwd()
-      })
+    , options       = extend({
+        execArgv : filteredArgs
+      , env      : process.env
+      , cwd      : process.cwd()
+    }, workerOptions)
+    , child         = childProcess.fork(childModule, process.argv, options)
 
   child.send({ module: forkModule })
 

--- a/tests/child.js
+++ b/tests/child.js
@@ -12,9 +12,11 @@ module.exports = function (timeout, callback) {
 
 
 module.exports.args = function (callback) {
-  console.log(process.argv)
-  console.log(process.execArgv)
-  callback()
+  callback(null, {
+      argv     : process.argv
+    , cwd      : process.cwd()
+    , execArgv : process.execArgv
+  })
 }
 
 

--- a/tests/debug.js
+++ b/tests/debug.js
@@ -4,7 +4,8 @@ const workerFarm = require('../')
     , workers    = workerFarm(require.resolve('./child'), ['args'])
 
 
-workers.args(function() {
+workers.args(function(err, result) {
+  console.log(result);
   workerFarm.end(workers)
   console.log('FINISHED')
   process.exit(0)


### PR DESCRIPTION
With this PR, a new object called `workerOptions` is added to the list of options. This options will be passed to `childProcess.fork` when calling it; but the defaults (e.g. `cwd`, `env` or the parent arguments passed to `node` will be kept as defaults).

The rationale behind the change is to allow further options to be passed. For example, workers might need to execute on a particular folder or need a different growing percentage than their main `node` process.

I've also added a test verifying that `cwd` and `execArgv` are overridden/passed, and updated the `README.md` to reflect those changes.