### PR TITLE
Add "stdout" and "stderr" streams to farms

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ Worker Farm allows me to spin up multiple JVMs to be controlled by Node, and hav
 
 ## API
 
-Worker Farm exports a main function and an `end()` method. The main function sets up a "farm" of coordinated child-process workers and it can be used to instantiate multiple farms, all operating independently.
+Worker Farm exports a main function and some helper methods:
+  * The main function sets up a "farm" of coordinated child-process workers and it can be used to instantiate multiple farms, all operating independently.
+  * The `end()` method allows to finalize the execution of all workers of a farm.
+  * The `stdout()` and `stderr()` methods return each a stream where all the `stdout` and `stderr` from other workers are respectively piped.
 
 ### workerFarm([options, ]pathToModule[, exportedMethods])
 

--- a/lib/farm.js
+++ b/lib/farm.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const mergeStream = require('merge-stream')
+
 const DEFAULT_OPTIONS = {
           maxCallsPerWorker           : Infinity
         , maxConcurrentWorkers        : require('os').cpus().length
@@ -22,6 +24,13 @@ function Farm (options, path) {
   this.options     = extend(DEFAULT_OPTIONS, options)
   this.path        = path
   this.activeCalls = 0
+  this.stdout      = mergeStream()
+  this.stderr      = mergeStream()
+
+  // child streams are piped and not inherited, so we -pipe them here to the
+  // parent stdout and stderr, which is the "inherit" behavior.
+  this.stdout.pipe(process.stdout)
+  this.stderr.pipe(process.stderr)
 }
 
 
@@ -112,6 +121,9 @@ Farm.prototype.startChild = function () {
         , activeCalls : 0
         , exitCode    : null
       }
+
+  this.stdout.add(forked.child.stdout)
+  this.stderr.add(forked.child.stderr)
 
   forked.child.on('message', this.receive.bind(this))
   forked.child.once('exit', function (code) {

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -13,6 +13,7 @@ function fork (forkModule) {
           execArgv: filteredArgs
         , env: process.env
         , cwd: process.cwd()
+        , silent: true
       })
 
   child.send({ module: forkModule })

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,14 +21,39 @@ function farm (options, path, methods) {
   return api
 }
 
-
-function end (api, callback) {
+function get (api) {
   for (let i = 0; i < farms.length; i++)
     if (farms[i] && farms[i].api === api)
-      return farms[i].farm.end(callback)
-  process.nextTick(callback.bind(null, 'Worker farm not found!'))
+      return farms[i].farm;
+  return null
 }
 
 
-module.exports     = farm
-module.exports.end = end
+function stdout (api) {
+  let farm = get(api);
+  if (farm)
+    return farm.stdout
+  throw new ReferenceError('Worker farm not found!')
+}
+
+
+function stderr (api) {
+  let farm = get(api);
+  if (farm)
+    return farm.stderr
+  throw new ReferenceError('Worker farm not found!')
+}
+
+
+function end (api, callback) {
+  let farm = get(api);
+  if (farm)
+    return farm.end(callback)
+  process.nextTick(callback.bind(null, new ReferenceError('Worker farm not found!')))
+}
+
+
+module.exports        = farm
+module.exports.end    = end
+module.exports.stdout = stdout
+module.exports.stderr = stderr

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "errno": "^0.1.4",
+    "merge-stream": "^1.0.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {

--- a/tests/child.js
+++ b/tests/child.js
@@ -49,6 +49,12 @@ module.exports.err = function (type, message, data, callback) {
 }
 
 
+module.exports.writeToStdout = function (str, callback) {
+  process.stdout.write(str);
+  callback();
+}
+
+
 module.exports.block = function () {
   while (true);
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -270,6 +270,30 @@ tape('multiple concurrent calls', function (t) {
 })
 
 
+tape.only('global stdout and stderr are exposed', function (t) {
+  t.plan(4)
+
+  let child  = workerFarm({ maxConcurrentWorkers: 2, maxConcurrentCallsPerWorker: 1 }, childPath, [ 'writeToStdout' ])
+    , buffer = ''
+
+  workerFarm.stdout(child).on('data', function (data) {
+    buffer += data
+
+    // if both "boo" and "bar" are present in the buffer (in whatever order)...
+    if ((buffer.match(/foo|bar/g) || []).length === 2) {
+      t.ok(true, 'both workers output to stdout')
+    }
+  })
+
+  child.writeToStdout('foo', function () { t.ok(true, 'called worker #1') })
+  child.writeToStdout('bar', function () { t.ok(true, 'called worker #2') })
+
+  workerFarm.end(child, function() {
+    t.pass('woerkFarm ended')
+  })
+})
+
+
 // call a method that will die with a probability of 0.5 but expect that
 // we'll get results for each of our calls anyway
 tape('durability', function (t) {


### PR DESCRIPTION
Sometimes a finer control is desired over output streams coming from different workers. By adding two methods to the main API (`stdout(<Farm>)` and `stderr(<Farm>)`) we allow users to control what they want to do with the output.

In order to keep the old behavior, I added a `pipe` into the main process, so that child `stdout` and `stderr` end up in the parent ones, as it was happening before (i.e. with `silent` set to `false`). But with this PR, this could change its default behavior to be cleaner (and let the user decide). If so, only the two lines added at the end of the `Farm` constructor should be removed.

I added a test and updated the docs as well reflecting new APIs.