### PR TITLE
lib: fix ERR_IPC_CHANNEL_CLOSED send error

### DIFF
--- a/lib/fork.js
+++ b/lib/fork.js
@@ -15,17 +15,15 @@ function fork (forkModule) {
         , cwd: process.cwd()
       })
 
+  child.on('error', function() {
+    // this *should* be picked up by onExit and the operation requeued
+  })
+
   child.send({ module: forkModule })
 
   // return a send() function for this child
   return {
-      send  : function (data) {
-        try {
-          child.send(data)
-        } catch (e) {
-          // this *should* be picked up by onExit and the operation requeued
-        }
-      }
+      send  : child.send.bind(child)
     , child : child
   }
 }


### PR DESCRIPTION
Node.js 9.x emits the 'error' event asynchronously.  That means catching
it with a try/catch statement no longer works.

Fixes: https://github.com/nodejs/node/issues/16322