### PR TITLE
disable concurrency in case of libuv/libuv#1459

### DIFF
--- a/lib/farm.js
+++ b/lib/farm.js
@@ -2,7 +2,7 @@
 
 const DEFAULT_OPTIONS = {
           maxCallsPerWorker           : Infinity
-        , maxConcurrentWorkers        : require('os').cpus().length
+        , maxConcurrentWorkers        : (require('os').cpus()||{length:1}).length
         , maxConcurrentCallsPerWorker : 10
         , maxConcurrentCalls          : Infinity
         , maxCallTime                 : Infinity // exceed this and the whole worker is terminated

--- a/lib/farm.js
+++ b/lib/farm.js
@@ -2,7 +2,7 @@
 
 const DEFAULT_OPTIONS = {
           maxCallsPerWorker           : Infinity
-        , maxConcurrentWorkers        : (require('os').cpus()||{length:1}).length
+        , maxConcurrentWorkers        : (require('os').cpus() || { length: 1 }).length
         , maxConcurrentCallsPerWorker : 10
         , maxConcurrentCalls          : Infinity
         , maxCallTime                 : Infinity // exceed this and the whole worker is terminated


### PR DESCRIPTION
When the number of workers/cpus can't be determined, assume 1.
termux/termux-packages#1798
There must be a better workaround?