### PR TITLE
Remove xtend in favor of Object.assign

### DIFF
--- a/lib/farm.js
+++ b/lib/farm.js
@@ -11,15 +11,14 @@ const DEFAULT_OPTIONS = {
         , autoStart                   : false
       }
 
-const extend                  = require('xtend')
-    , fork                    = require('./fork')
+const fork                    = require('./fork')
     , TimeoutError            = require('errno').create('TimeoutError')
     , ProcessTerminatedError  = require('errno').create('ProcessTerminatedError')
     , MaxConcurrentCallsError = require('errno').create('MaxConcurrentCallsError')
 
 
 function Farm (options, path) {
-  this.options     = extend(DEFAULT_OPTIONS, options)
+  this.options     = Object.assign({}, DEFAULT_OPTIONS, options)
   this.path        = path
   this.activeCalls = 0
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "url": "https://github.com/rvagg/node-worker-farm.git"
   },
   "dependencies": {
-    "errno": "~0.1.7",
-    "xtend": "~4.0.1"
+    "errno": "~0.1.7"
   },
   "devDependencies": {
     "tape": "~4.9.0"


### PR DESCRIPTION
`Object.assign` is supported since Node.js 4