### PR TITLE
Correct a bug related to forcedKillTime.

### DIFF
--- a/lib/farm.js
+++ b/lib/farm.js
@@ -132,7 +132,7 @@ Farm.prototype.stopChild = function (childId) {
     setTimeout(function () {
       if (child.exitCode === null)
         child.child.kill('SIGKILL')
-    }, this.options.forcedKillTime)
+    }, this.options.forcedKillTime).unref()
     ;delete this.children[childId]
     this.activeChildren--
   }


### PR DESCRIPTION
The bug revolved basically around using setTimeout which was keeping the
main thread alive after the workers were dead. The fix is to use setInterval
and call clearInterval when the forceKillTime has elapsed.