### PR TITLE
Exported additional interfaces for passed in objects

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,40 +2,14 @@ import { ForkOptions } from "child_process";
 
 export = Farm;
 
-declare function Farm(name: string): Workers;
-declare function Farm(name: string, exportedMethods: string[]): Workers;
-declare function Farm(options: FarmOptions, name: string): Workers;
+declare function Farm(name: string): Farm.Workers;
+declare function Farm(name: string, exportedMethods: string[]): Farm.Workers;
+declare function Farm(options: Farm.FarmOptions, name: string): Farm.Workers;
 declare function Farm(
-  options: FarmOptions,
+  options: Farm.FarmOptions,
   name: string,
   exportedMethods: string[],
-): Workers;
-
-interface Workers {
-  (callback: WorkerCallback): void;
-  (arg1: any, callback: WorkerCallback): void;
-  (arg1: any, arg2: any, callback: WorkerCallback): void;
-  (arg1: any, arg2: any, arg3: any, callback: WorkerCallback): void;
-  (arg1: any, arg2: any, arg3: any, arg4: any, callback: WorkerCallback): void;
-}
-
-interface FarmOptions {
-  maxCallsPerWorker?: number;
-  maxConcurrentWorkers?: number;
-  maxConcurrentCallsPerWorker?: number;
-  maxConcurrentCalls?: number;
-  maxCallTime?: number;
-  maxRetries?: number;
-  autoStart?: boolean;
-  workerOptions?: ForkOptions;
-}
-
-type WorkerCallback =
-  | WorkerCallback0
-  | WorkerCallback1
-  | WorkerCallback2
-  | WorkerCallback3
-  | WorkerCallback4;
+): Farm.Workers;
 
 type WorkerCallback0 = () => void;
 type WorkerCallback1 = (arg1: any) => void;
@@ -45,4 +19,36 @@ type WorkerCallback4 = (arg1: any, arg2: any, arg3: any, arg4: any) => void;
 
 declare namespace Farm {
   export function end(workers: Workers): void;
+
+  export interface Workers {
+    (callback: WorkerCallback): void;
+    (arg1: any, callback: WorkerCallback): void;
+    (arg1: any, arg2: any, callback: WorkerCallback): void;
+    (arg1: any, arg2: any, arg3: any, callback: WorkerCallback): void;
+    (
+      arg1: any,
+      arg2: any,
+      arg3: any,
+      arg4: any,
+      callback: WorkerCallback,
+    ): void;
+  }
+
+  export interface FarmOptions {
+    maxCallsPerWorker?: number;
+    maxConcurrentWorkers?: number;
+    maxConcurrentCallsPerWorker?: number;
+    maxConcurrentCalls?: number;
+    maxCallTime?: number;
+    maxRetries?: number;
+    autoStart?: boolean;
+    workerOptions?: ForkOptions;
+  }
+
+  export type WorkerCallback =
+    | WorkerCallback0
+    | WorkerCallback1
+    | WorkerCallback2
+    | WorkerCallback3
+    | WorkerCallback4;
 }


### PR DESCRIPTION
Hi Rvagg,

Another update for the definition files:
* The farm api type, (named Workers in the ts def), has been made public, for those passing the api around.
* The farm options, (named FarmOptions), has also been made public, for those dynamically creating the options, or again, passing it around.
* The worker callback, same again.

FYI, I checked the definition file prior to my previous update, these interfaces for these objects weren't exported either, so this is an improvement.

The only other thing I can think of that needs to be improved is adding the name of exported functions which are then access through the api to fork the child process; which to the best of my knowledge is not possible with typescript yet.

Thanks Rvagg.