### PR TITLE
fix: setTimeout.unref is undefined

### DIFF
--- a/lib/farm.js
+++ b/lib/farm.js
@@ -132,7 +132,7 @@ Farm.prototype.stopChild = function (childId) {
     setTimeout(function () {
       if (child.exitCode === null)
         child.child.kill('SIGKILL')
-    }, this.options.forcedKillTime).unref()
+    }, this.options.forcedKillTime)
     ;delete this.children[childId]
     this.activeChildren--
   }


### PR DESCRIPTION
when I called `farm.end(workers)`, `setTimeout.unref is undefined` is thrown