### PR TITLE
fix: child connected failed

### DIFF
--- a/lib/farm.js
+++ b/lib/farm.js
@@ -101,17 +101,22 @@ Farm.prototype.onExit = function (childId) {
 
 // start a new worker
 Farm.prototype.startChild = function () {
+  let forked = fork(this.path, this.options.workerOptions)
+  if (!forked.send) {
+    throw new Error('child process fork failed, may the resource has no more space')
+    return
+  }
+
   this.childId++
 
-  let forked = fork(this.path, this.options.workerOptions)
-    , id     = this.childId
-    , c      = {
-          send        : forked.send
-        , child       : forked.child
-        , calls       : []
-        , activeCalls : 0
-        , exitCode    : null
-      }
+  let id       = this.childId
+      , c      = {
+        send        : forked.send
+      , child       : forked.child
+      , calls       : []
+      , activeCalls : 0
+      , exitCode    : null
+    }
 
   forked.child.on('message', this.receive.bind(this))
   forked.child.once('exit', function (code) {
@@ -132,7 +137,7 @@ Farm.prototype.stopChild = function (childId) {
     setTimeout(function () {
       if (child.exitCode === null)
         child.child.kill('SIGKILL')
-    }, this.options.forcedKillTime).unref()
+    }, this.options.forcedKillTime)
     ;delete this.children[childId]
     this.activeChildren--
   }

--- a/lib/fork.js
+++ b/lib/fork.js
@@ -20,11 +20,13 @@ function fork (forkModule, workerOptions) {
     // this *should* be picked up by onExit and the operation requeued
   })
 
-  child.send({ module: forkModule })
+  if (child.connected) {
+    child.send({ module: forkModule })
+  }
 
   // return a send() function for this child
   return {
-      send  : child.send.bind(child)
+      send  : child.connected ? child.send.bind(child) : null
     , child : child
   }
 }


### PR DESCRIPTION
When I forked lots of child-process.
`child.connected` is `false`, and `child.send` is undefined.

 [child-process#connected](https://nodejs.org/dist/latest-v8.x/docs/api/child_process.html#child_process_subprocess_connected)

- OS: macOS 10.12.6