### PR TITLE
Add missing type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,7 @@ declare function Farm(
 ): Workers;
 
 interface Workers {
+  [x: string]: Workers,
   (callback: WorkerCallback): void;
   (arg1: any, callback: WorkerCallback): void;
   (arg1: any, arg2: any, callback: WorkerCallback): void;


### PR DESCRIPTION
This is necessary when using `exportedMethods`