### PR TITLE
fix setTimeout unref error

### DIFF
--- a/lib/farm.js
+++ b/lib/farm.js
@@ -25,6 +25,8 @@ function Farm (options, path) {
   this.activeCalls = 0
 }
 
+// to support unref
+const { setTimeout } = require('timers')
 
 // make a handle to pass back in the form of an external API
 Farm.prototype.mkhandle = function (method) {


### PR DESCRIPTION
This fixes setTimeour unref error not defined error. 

Related: https://github.com/electron/electron/issues/21162